### PR TITLE
Makes the FlatButton class open so that it allows subclassing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log
 
  - Fixed an issue that would cause images in `PressableButton` to not move properly on highlight.
    [#14](https://github.com/TakeScoop/SwiftyButton/issues/14)
+ - Made the `FlatButton` class open to allow subclassing.
 
 ## [0.8.0]
 

--- a/SwiftyButton/FlatButton.swift
+++ b/SwiftyButton/FlatButton.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @IBDesignable
-public class FlatButton: UIButton {
+open class FlatButton: UIButton {
     
     public enum Defaults {
         public static var color = UIColor(red: 52 / 255, green: 152 / 255, blue: 219 / 255, alpha: 1)


### PR DESCRIPTION
This PR switches `FlatButton` from `public` to `open`, allowing subclassing. This does not make any of the properties open.